### PR TITLE
Update Checkout step to avoid deprecated

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     name: 💅 Lint
     steps:
       - name: 👍 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 📥 Install Dependencies
         run: npm install


### PR DESCRIPTION
Acutal message with v2: Node.js 12 actions are deprecated